### PR TITLE
Rename `Track::loved` to `Track::favorited`

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The library entry point is `AppleMusic`. From there, you can:
 - Get the application's data - `AppleMusic::get_application_data();` -> `ApplicationData`
 - Get the current track - `AppleMusic::get_current_track();` -> `Track`
   - Track can then be used directly:
-    - Love / dislike Track - `track.set_loved(true);` or `track.set_disliked(true);`
+    - Favorite / dislike Track - `track.set_favorited(true);` or `track.set_disliked(true);`
     - Download Track - `track.download()`
     - Reveal Track in Player - `track.reveal_in_player()`
 
@@ -63,7 +63,7 @@ println!("{}", current_track.name()); // "An awesome song!"
 
 println!("{}", current_track.artwork_url()); // Prints the direct url for the Artwork of the Track.
 
-current_track.set_loved(true); // Track is now loved!
+current_track.set_favorited(true); // Track is now favorited!
 
 AppleMusic::next_track(); // Goes to next track.
 
@@ -85,7 +85,7 @@ This crate only works on MacOs, and has only been tested with macOS 13.4.1 and A
 
 I would be more than happy provide support for other version of MacOs / Apple Music, do not hesitate to open an issue if you are facing failures!
 
-## Next Steps 
+## Next Steps
 _Before v1.0:_
 - Finish to add remaining classes & methods:
   - `ADD()`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@
 //! - Get the application's data - `AppleMusic::get_application_data();` -> `ApplicationData`
 //! - Get the current track - `AppleMusic::get_current_track();` -> `Track`
 //!   - Track can then be used directly:
-//!     - Love / dislike Track - `track.set_loved(true);` or `track.set_disliked(true);`
+//!     - Favorite / dislike Track - `track.set_favorited(true);` or `track.set_disliked(true);`
 //!     - Download Track - `track.download()`
 //!     - Reveal Track in Player - `track.reveal_in_player()`
 //
@@ -63,7 +63,7 @@
 //
 //! println!("{}", current_track.artwork_url()); //! Prints the direct url for the Artwork of the Track.
 //
-//! current_track.set_loved(true); //! Track is now loved!
+//! current_track.set_favorited(true); //! Track is now favorited!
 //
 //! AppleMusic::next_track(); //! Goes to next track.
 //

--- a/src/playlist.rs
+++ b/src/playlist.rs
@@ -32,8 +32,8 @@ pub struct Playlist {
     /// The total length of all tracks (in seconds)
     pub duration: Option<f32>,
 
-    /// Is this playlist loved?
-    pub loved: bool,
+    /// Is this playlist favorited?
+    pub favorited: bool,
 
     /// Folder which contains this playlist (if any)
     pub parent: Option<Box<Playlist>>,

--- a/src/track.rs
+++ b/src/track.rs
@@ -33,8 +33,8 @@ pub struct Track {
     /// Is the album for this track disliked?
     pub album_disliked: bool,
 
-    /// Is the album for this track loved?
-    pub album_loved: bool,
+    /// Is the album for this track favorited?
+    pub album_favorited: bool,
 
     /// The rating of the album for this track (0 to 100)
     pub album_rating: Option<i16>,
@@ -132,8 +132,8 @@ pub struct Track {
     /// The long description of the track
     pub long_description: Option<String>,
 
-    /// Is this track loved?
-    pub loved: bool,
+    /// Is this track favorited?
+    pub favorited: bool,
 
     /// The lyrics of the track
     pub lyrics: Option<String>,
@@ -301,10 +301,10 @@ impl Track {
         Ok(())
     }
 
-    /// Loves / "Unloves" a Track.
-    pub fn set_loved(&self, value: bool) -> Result<(), Error> {
+    /// Favorites / "Unfavorites" a Track.
+    pub fn set_favorited(&self, value: bool) -> Result<(), Error> {
         let cmd = format!(
-            "Application('Music').tracks.byId({}).loved = {}",
+            "Application('Music').tracks.byId({}).favorited = {}",
             self.id, value
         );
 
@@ -350,7 +350,6 @@ impl Track {
         }
     }
 
-
     fn fetch_itunes_store_by_request(&mut self, request: String) {
         let mut res = reqwest::blocking::get(request).unwrap();
         let mut body = String::new();
@@ -361,22 +360,19 @@ impl Track {
                 self.artwork_url = Some(search.results[0].clone().artwork_url_100);
                 self.track_url = Some(search.results[0].clone().track_view_url);
             } else {
-                let result = search
-                    .results
-                    .iter()
-                    .find(|result|
-                              ( &result.track_name.to_lowercase() == &self.name.to_lowercase()
-                                  || &result.track_censored_name.to_lowercase() == &self.name.to_lowercase() )
-                        && ( &result.artist_name.to_lowercase() == &self.artist.to_lowercase()
-                                  || &result.collection_name.to_lowercase() == &self.album.to_lowercase() )
-                    );
+                let result = search.results.iter().find(|result| {
+                    (&result.track_name.to_lowercase() == &self.name.to_lowercase()
+                        || &result.track_censored_name.to_lowercase() == &self.name.to_lowercase())
+                        && (&result.artist_name.to_lowercase() == &self.artist.to_lowercase()
+                            || &result.collection_name.to_lowercase() == &self.album.to_lowercase())
+                });
 
                 match result {
                     Some(data) => {
                         self.artwork_url = Some(data.clone().artwork_url_100);
                         self.track_url = Some(data.clone().track_view_url);
                     }
-                    None => { () }
+                    None => (),
                 }
             }
         }


### PR DESCRIPTION
The `loved` field on tracks was renamed in Apple Music to `favorited`, so this PR reflects that. Resolves #10.

... Also, by the way, totally unrelated, but I noticed that you do this sort of thing a fair bit:

```rs
pub fn get_current_track() -> Result<Track, Error> {
    match ScriptController.execute_script::<Track>(ParamType::CurrentTrack, None, None) {
        Ok(data) => Ok(data),
        Err(err) => Err(err),
    }
}
```

and I just wanted to let you know that it can be simplified to just:

```rs
pub fn get_current_track() -> Result<Track, Error> {
   ScriptController.execute_script::<Track>(ParamType::CurrentTrack, None, None)
}
```

since `execute_script()` here has the same return type as `get_current_track()`. Hope that's helpful ^^

Oh, also also, I have an auto formatter in my editor so let me know if you don't like how some things have happened to be reformatted and I'll change it back ^^'