### PR TITLE
Properly serde renamed devices in AirplayDeviceKind

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,11 @@ categories = ["api-bindings", "gui", "multimedia"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde_json = "1.0.108"
-serde = { version = "1.0.193", features = ["derive"] }
+serde_json = "1.0.128"
+serde = { version = "1.0.210", features = ["derive"] }
 log = "0.4.20"
 env_logger = "0.10.1"
-strum = { version = "0.25.0", features = ["derive"] }
-strum_macros = "0.25.3"
+strum = { version = "0.26.3", features = ["derive"] }
+strum_macros = "0.26.4"
 reqwest = { version = "0.11.23", features = ["blocking"] }
 urlencoding = "2.1.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "apple-music"
 authors = ["Dylan Cattelan <dylan.cattelan@gmail.com"]
-version = "0.11.4"
+version = "0.11.5"
 edition = "2021"
 description = "A Rust Library to fully control local MacOS Apple Music player."
 documentation = "https://docs.rs/apple-music/latest"

--- a/src/application_data.rs
+++ b/src/application_data.rs
@@ -256,7 +256,9 @@ pub enum AirplayDeviceKind {
     Computer,
     AirportExpress,
     AppleTV,
+    #[serde(rename = "Airplay device")]
     AirplayDevice,
+    #[serde(rename = "Bluetooth device")]
     BluetoothDevice,
     HomePod,
     Unknown,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,3 +106,4 @@ pub use apple_music::*;
 pub use application_data::*;
 pub use playlist::*;
 pub use track::*;
+pub use error::*;


### PR DESCRIPTION
Serde couldn't properly deserialize JSON String when requesting ApplicationData because of AirplayDeviceKind not named correctly.