### PR TITLE
fix: track deserialization issue for date added field

### DIFF
--- a/src/track.rs
+++ b/src/track.rs
@@ -83,7 +83,7 @@ pub struct Track {
     pub database_id: i32,
 
     /// The date the track was added to the playlist
-    pub date_added: String,
+    pub date_added: Option<String>,
 
     /// The description of the track
     pub description: String,


### PR DESCRIPTION
This field is not always present in the JSON response from the music app. As far as I can tell, it represents when the track was added to an individual's library, but not every track they play is in their library (or being play from a playlist).

Here's an example of two payloads I used to compare.

### bad (deserialization fails without the change in this PR)

```json
{
  "class": "sharedTrack",
  "id": 40047,
  "index": 274,
  "name": "Album für die Jugend, Op. 68: No. 30, Sehr langsam",
  "persistentID": "3B0C53611378D2BE",
  "databaseID": 22663,
  "time": "3:33",
  "duration": 213.06700134277344,
  "artist": "Fabrizio Chiovetta",
  "albumArtist": "Fabrizio Chiovetta",
  "composer": "Robert Schumann",
  "album": "Schumann: Fantasie, Arabeske, Kinderszenen",
  "genre": "Classical",
  "bitRate": 256,
  "sampleRate": 44100,
  "trackCount": 0,
  "trackNumber": 18,
  "discCount": 1,
  "discNumber": 1,
  "size": 7523820,
  "volumeAdjustment": 0,
  "year": 2022,
  "comment": "",
  "eq": "",
  "kind": "Apple Music AAC audio file",
  "mediaKind": "song",
  "enabled": true,
  "start": 0,
  "finish": 213.06700134277344,
  "playedCount": 0,
  "playedDate": "2025-07-09T14:32:25.000Z",
  "skippedCount": 0,
  "compilation": false,
  "rating": 0,
  "bpm": 0,
  "grouping": "",
  "bookmarkable": false,
  "bookmark": 0,
  "shufflable": true,
  "lyrics": "",
  "category": "",
  "description": "",
  "episodeNumber": 0,
  "unplayed": false,
  "sortName": "Album für die Jugend, Op. 68: No. 30, Sehr langsam",
  "sortAlbum": "Schumann: Fantasie, Arabeske, Kinderszenen",
  "sortArtist": "Fabrizio Chiovetta",
  "sortComposer": "",
  "sortAlbumArtist": "",
  "releaseDate": "2022-12-16T08:00:00.000Z",
  "favorited": false,
  "disliked": false,
  "albumFavorited": false,
  "albumDisliked": false,
  "cloudStatus": "subscription",
  "work": "Album für die Jugend, Op. 68",
  "movement": "No. 30, Sehr langsam",
  "movementNumber": 0,
  "movementCount": 42
}
```


### good (deserialization succeeds)

```json
{
  "class": "sharedTrack",
  "id": 40643,
  "index": 19,
  "name": "All Chilled Out (DJ Ezasscul)",
  "persistentID": "78097EA2C9285A37",
  "databaseID": 15687,
  "dateAdded": "2025-01-09T20:10:16.000Z",
  "time": "4:01",
  "duration": 241.73300170898438,
  "artist": "DJ Ezasscul",
  "albumArtist": "DJ Ezasscul",
  "composer": "DJ Ezasscul",
  "album": "Jazz Meditation Trilogy (Deluxe Edition)",
  "genre": "Hip-Hop/Rap",
  "bitRate": 256,
  "sampleRate": 44100,
  "trackCount": 40,
  "trackNumber": 15,
  "discCount": 1,
  "discNumber": 1,
  "size": 8424393,
  "volumeAdjustment": 0,
  "year": 2011,
  "comment": "",
  "eq": "",
  "kind": "Apple Music AAC audio file",
  "mediaKind": "song",
  "modificationDate": "2025-01-09T20:10:16.000Z",
  "enabled": true,
  "start": 0,
  "finish": 241.73300170898438,
  "playedCount": 1,
  "playedDate": "2025-01-31T14:49:10.000Z",
  "skippedCount": 0,
  "compilation": false,
  "rating": 0,
  "bpm": 0,
  "grouping": "",
  "bookmarkable": false,
  "bookmark": 0,
  "shufflable": true,
  "lyrics": "",
  "category": "",
  "description": "",
  "episodeNumber": 0,
  "unplayed": false,
  "sortName": "All Chilled Out (DJ Ezasscul)",
  "sortAlbum": "Jazz Meditation Trilogy (Deluxe Edition)",
  "sortArtist": "DJ Ezasscul",
  "sortComposer": "",
  "sortAlbumArtist": "",
  "releaseDate": "2011-02-09T12:00:00.000Z",
  "favorited": false,
  "disliked": false,
  "albumFavorited": false,
  "albumDisliked": false,
  "cloudStatus": "subscription",
  "work": "",
  "movement": "",
  "movementNumber": 0,
  "movementCount": 0
}
```